### PR TITLE
Feat: ColumnKillerState + little refactor

### DIFF
--- a/src/Myg-SameGame-Tests/SameGameBoardElementTest.class.st
+++ b/src/Myg-SameGame-Tests/SameGameBoardElementTest.class.st
@@ -305,6 +305,150 @@ SameGameBoardElementTest >> testClickOnBombWithNullAroundDoesNotThrowAnyThing [
 ]
 
 { #category : 'tests' }
+SameGameBoardElementTest >> testClickOnColumnKiller [
+
+	| graphicBoard |
+	"Y: Yellow , B: Blue , G: Green , R: Red , Cr: ColumnKiller
+	resents this grid:
+	 | R | R | Y  |
+	 | B | Cr | B|
+	 | Y | B | R |
+	 
+	"
+	board configureGrid: ((CTNewArray2D width: 3 height: 3)
+			 at: 1 @ 1 put: SGBox red;
+			 at: 2 @ 1 put: SGBox red;
+			 at: 3 @ 1 put: SGBox yellow;
+			 at: 1 @ 2 put: SGBox blue;
+			 at: 2 @ 2 put: SGBox columnKiller;
+			 at: 3 @ 2 put: SGBox blue;
+			 at: 1 @ 3 put: SGBox red;
+			 at: 2 @ 3 put: SGBox blue ;
+			 at: 3 @ 3 put: SGBox yellow;
+			 yourself).
+
+	graphicBoard := SGBoardElement new.
+	graphicBoard grid: board grid.
+	board hitBoxOnx: 2 y: 2.
+
+
+	"Y: Yellow , B: Blue , G: Green , R: Red , Cr: ColumnKiller
+	resents this grid:
+	 | R | R | Y  |
+	 | B | Cr | B|
+	 | Y | B | R |
+	"
+
+	self assert: (board grid at: 1 @ 1) literal equals: 'R'.
+	self assert: (board grid at: 2 @ 1) literal equals: 'Y'.
+	self assert: (board grid at: 3 @ 1) literal equals: 'N'.
+
+	self assert: (board grid at: 1 @ 2) literal equals: 'B'.
+	self assert: (board grid at: 2 @ 2) literal equals: 'B'.
+	self assert: (board grid at: 3 @ 2) literal equals: 'N'.
+
+	self assert: (board grid at: 1 @ 3) literal equals: 'R'.
+	self assert: (board grid at: 2 @ 3) literal equals: 'Y'.
+	self assert: (board grid at: 3 @ 3) literal equals: 'N'
+]
+
+{ #category : 'tests' }
+SameGameBoardElementTest >> testClickOnColumnKillerWithNullState [
+
+	| graphicBoard |
+	"Y: Yellow , B: Blue , G: Green , R: Red , Cr: ColumnKiller
+	resents this grid:
+	 | R | N | Y  |
+	 | B | Cr | B|
+	 | Y | N | R |
+	 
+	"
+	board configureGrid: ((CTNewArray2D width: 3 height: 3)
+			 at: 1 @ 1 put: SGBox red;
+			 at: 2 @ 1 put: SGBox null;
+			 at: 3 @ 1 put: SGBox yellow;
+			 at: 1 @ 2 put: SGBox blue;
+			 at: 2 @ 2 put: SGBox columnKiller;
+			 at: 3 @ 2 put: SGBox blue;
+			 at: 1 @ 3 put: SGBox red;
+			 at: 2 @ 3 put: SGBox null;
+			 at: 3 @ 3 put: SGBox yellow;
+			 yourself).
+
+	graphicBoard := SGBoardElement new.
+	graphicBoard grid: board grid.
+	board hitBoxOnx: 2 y: 2.
+
+
+	"Y: Yellow , B: Blue , G: Green , R: Red , Cr: ColumnKiller
+	resents this grid:
+	 | R | R | Y  |
+	 | B | Cr | B|
+	 | Y | B | R |
+	"
+
+	self assert: (board grid at: 1 @ 1) literal equals: 'R'.
+	self assert: (board grid at: 2 @ 1) literal equals: 'Y'.
+	self assert: (board grid at: 3 @ 1) literal equals: 'N'.
+
+	self assert: (board grid at: 1 @ 2) literal equals: 'B'.
+	self assert: (board grid at: 2 @ 2) literal equals: 'B'.
+	self assert: (board grid at: 3 @ 2) literal equals: 'N'.
+
+	self assert: (board grid at: 1 @ 3) literal equals: 'R'.
+	self assert: (board grid at: 2 @ 3) literal equals: 'Y'.
+	self assert: (board grid at: 3 @ 3) literal equals: 'N'
+]
+
+{ #category : 'tests' }
+SameGameBoardElementTest >> testClickOnColumnKillerWithOtherColumnKillerOnTheSameColumn [
+
+	| graphicBoard |
+	"Y: Yellow , B: Blue , G: Green , R: Red , Cr: ColumnKiller
+	resents this grid:
+	 | R | Cr | Y  |
+	 | B | Cr | B|
+	 | Y | Cr | R |
+	 
+	"
+	board configureGrid: ((CTNewArray2D width: 3 height: 3)
+			 at: 1 @ 1 put: SGBox red;
+			 at: 2 @ 1 put: SGBox columnKiller;
+			 at: 3 @ 1 put: SGBox yellow;
+			 at: 1 @ 2 put: SGBox blue;
+			 at: 2 @ 2 put: SGBox columnKiller;
+			 at: 3 @ 2 put: SGBox blue;
+			 at: 1 @ 3 put: SGBox red;
+			 at: 2 @ 3 put: SGBox columnKiller;
+			 at: 3 @ 3 put: SGBox yellow;
+			 yourself).
+
+	graphicBoard := SGBoardElement new.
+	graphicBoard grid: board grid.
+	board hitBoxOnx: 2 y: 2.
+
+
+	"Y: Yellow , B: Blue , G: Green , R: Red , Cr: ColumnKiller
+	resents this grid:
+	 | R | Cr | Y  |
+	 | B | Cr | B|
+	 | Y | Cr | R |
+	"
+
+	self assert: (board grid at: 1 @ 1) literal equals: 'R'.
+	self assert: (board grid at: 2 @ 1) literal equals: 'Y'.
+	self assert: (board grid at: 3 @ 1) literal equals: 'N'.
+
+	self assert: (board grid at: 1 @ 2) literal equals: 'B'.
+	self assert: (board grid at: 2 @ 2) literal equals: 'B'.
+	self assert: (board grid at: 3 @ 2) literal equals: 'N'.
+
+	self assert: (board grid at: 1 @ 3) literal equals: 'R'.
+	self assert: (board grid at: 2 @ 3) literal equals: 'Y'.
+	self assert: (board grid at: 3 @ 3) literal equals: 'N'
+]
+
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickOnIsolatedBoxNothingChanges [
 
 	self assert: (board grid at: 1 @ 1) literal equals: 'B'.

--- a/src/Myg-SameGame/SGAbstractState.class.st
+++ b/src/Myg-SameGame/SGAbstractState.class.st
@@ -32,7 +32,7 @@ SGAbstractState >> literal [
 ]
 
 { #category : 'as yet unclassified' }
-SGAbstractState >> propagateFromABox: aSquare [
+SGAbstractState >> propagateFromABox: aSGbox [
 
 	self subclassResponsibility
 ]

--- a/src/Myg-SameGame/SGBox.class.st
+++ b/src/Myg-SameGame/SGBox.class.st
@@ -24,6 +24,14 @@ SGBox class >> bomb [
 	^ self withState: SGBombState uniqueInstance
 ]
 
+{ #category : 'as yet unclassified' }
+SGBox class >> columnKiller [
+	"comment stating purpose of class-side method"
+	"scope: class-variables  &  class-instance-variables"
+
+	^ self withState: SGColumnKiller uniqueInstance
+]
+
 { #category : 'constants' }
 SGBox class >> green [
 
@@ -143,6 +151,22 @@ SGBox >> propagateBombState [
 { #category : 'propagating' }
 SGBox >> propagateClick [
 	self state propagateFromABox: self.
+]
+
+{ #category : 'as yet unclassified' }
+SGBox >> propagateColumnKillerState [
+	"comment stating purpose of instance-side method"
+
+	"scope: class-variables  &  instance-variables"
+
+	| x yMaxBoard yMinBoard |
+	x := self x.
+	yMaxBoard := board grid height.
+	yMinBoard := 1.
+	(self board hitList includes: self) ifTrue: [ ^ self ].
+	self board hitList add: self.
+	yMinBoard to: yMaxBoard do: [ :y |
+	self removeBox: (board boxAt: x @ y) ]
 ]
 
 { #category : 'as yet unclassified' }

--- a/src/Myg-SameGame/SGColumnKiller.class.st
+++ b/src/Myg-SameGame/SGColumnKiller.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : 'SGColumnKiller',
+	#superclass : 'SGSpecialState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
+}
+
+{ #category : 'accessing' }
+SGColumnKiller >> backgroundRepresentation [
+
+	^ Color lightOrange 
+]
+
+{ #category : 'testing' }
+SGColumnKiller >> literal [
+	^ 'Cr'
+]
+
+{ #category : 'as yet unclassified' }
+SGColumnKiller >> propagateFromABox: aSGBox [
+
+	^ aSGBox propagateColumnKillerState
+]


### PR DESCRIPTION
feat: add columnKiller and test for it change name for a parameter for propagate in abstract (oversight )

# Ajout d'un nouveau state à nos spécifiques state

## Que fait l'ajout : 
On a maintenant un state qui peut permettre de détruire toute une colonne d'un coup.

## Evolution : 
Même chose que pour le LineKiller => On pourrait penser à la réaction en chaîne ça pourrait être sympa ! 

# Point secondaire de cette PR : 
Changement sur ```SGAbstractState``` sur la méthode : ```propagateFromABox``` pour son paramètre passant de ASquare to SGBox (c'est plus cohérant c'est un oubli il aurait dû passer depuis LineKiller)